### PR TITLE
Fix template diagnostic

### DIFF
--- a/src/crystalProblemsFinder.ts
+++ b/src/crystalProblemsFinder.ts
@@ -34,7 +34,7 @@ export class CrystalProblemsFinder {
 						let diagnostic = new vscode.Diagnostic(range, problem.message, vscode.DiagnosticSeverity.Error)
 						let file: vscode.Uri
 						if (problem.file.length > 0) {
-							if (problem.file.endsWith('.ecr') || problem.file.endsWith('.slang')) {
+							if (!problem.file.endsWith('.cr')) {
 								file = vscode.Uri.file(vscode.workspace.rootPath + '/' + problem.file)
 							} else {
 								file = vscode.Uri.file(problem.file)

--- a/src/crystalProblemsFinder.ts
+++ b/src/crystalProblemsFinder.ts
@@ -34,7 +34,11 @@ export class CrystalProblemsFinder {
 						let diagnostic = new vscode.Diagnostic(range, problem.message, vscode.DiagnosticSeverity.Error)
 						let file: vscode.Uri
 						if (problem.file.length > 0) {
-							file = vscode.Uri.file(problem.file)
+							if (problem.file.endsWith('.ecr') || problem.file.endsWith('.slang')) {
+								file = vscode.Uri.file(vscode.workspace.rootPath + '/' + problem.file)
+							} else {
+								file = vscode.Uri.file(problem.file)
+							}
 						} else {
 							file = uri
 						}


### PR DESCRIPTION
Errors location on template files is incorrect because it is using a relative path.

This PR adds `workspaceRoot` to use absolute path and find errors correctly.
